### PR TITLE
Exposing the BASE16_VARIATION in a file

### DIFF
--- a/profile_helper.sh
+++ b/profile_helper.sh
@@ -12,14 +12,15 @@ base16_${theme}_${variation}()
   ln -fs $script ~/.base16_theme 
   export BASE16_THEME=base16-${theme}
   export BASE16_VARIATION=$variation
+  echo $variation > ~/.base16_variation.rc
   if type tmux_${variation} >/dev/null; then
     tmux_${variation}
   fi
   [ -f ~/.vimrc_background ] && rm ~/.vimrc_background
-  cat <<vimrc_background > ~/.vimrc_background
+  cat <<VIMRC_BACKGROUND > ~/.vimrc_background
 set background=$variation
 colorscheme base16-$theme
-vimrc_background
+VIMRC_BACKGROUND
 }
 FUNC
 done;


### PR DESCRIPTION
So that multiple sessions can
excess it. Therefore other apps (mutt)
can quickly switch between different
alternatives of color schemes.
